### PR TITLE
Corrected border to bordercolor

### DIFF
--- a/EditBind.py
+++ b/EditBind.py
@@ -321,7 +321,7 @@ class EditBindWindow(tk.Toplevel):
 
 if (__name__ == "__main__"):
     win = tk.Tk()
-    target = Bind(repr="SHIFT+Y em Does this work?$$+say <color #000000><bgcolor #FFFFFF75><border #FF0000><scale 1.0><duration 10>Yay!")
+    target = Bind(repr="SHIFT+Y em Does this work?$$+say <color #000000><bgcolor #FFFFFF75><bordercolor #FF0000><scale 1.0><duration 10>Yay!")
     def callback(result, bind):
         print(result)
         print(bind)

--- a/EditSlashCommand.py
+++ b/EditSlashCommand.py
@@ -323,7 +323,7 @@ class SlashCommandEditor(KeystoneEditFrame):
         
 if (__name__ == "__main__"):
     win = tk.Tk()
-    target = SlashCommand(repr="+say <color #000000><bgcolor #FFFFFF75><border #FF0000><scale 1.0><duration 10>Yay!")
+    target = SlashCommand(repr="+say <color #000000><bgcolor #FFFFFF75><bordercolor #FF0000><scale 1.0><duration 10>Yay!")
     editor = SlashCommandEditor(win, target)
     s = ttk.Style()
     s.configure('My.TFrame', background='red')

--- a/Keystone_test.py
+++ b/Keystone_test.py
@@ -18,11 +18,11 @@ import unittest
 class TestKeystoneUtils(unittest.TestCase):
 
     def test_ParseBacketedCodes(self):
-        input = "<color #000000><bgcolor #FFFFFF75> <border #FF0000><scale 1.0><duration 10>"
+        input = "<color #000000><bgcolor #FFFFFF75> <bordercolor #FF0000><scale 1.0><duration 10>"
         tests = [
                     ["color", "#000000"],
                     ["bgcolor", "#FFFFFF75"],
-                    ["border", "#FF0000"],
+                    ["bordercolor", "#FF0000"],
                     ["scale", "1.0"],
                     ["duration", "10"]
                 ]
@@ -115,7 +115,7 @@ class TestSlashCommand(unittest.TestCase):
         duration = "10"
         target = SlashCommand(name=name, text=text, color=color, background=background, transparency=transparency, border=border, scale=scale, duration=duration)
         actual = str(target)
-        expected = "say <color #000000><bgcolor #FFFFFF75><border #FF0000><scale 1.0><duration 10>Yay!"
+        expected = "say <color #000000><bgcolor #FFFFFF75><bordercolor #FF0000><scale 1.0><duration 10>Yay!"
         self.assertEqual(actual, expected)
 
     def test_FromString(self):
@@ -161,7 +161,7 @@ class TestSlashCommand(unittest.TestCase):
         border = "#FF0000"
         scale = "1.0"
         duration = "10"
-        target = SlashCommand(repr="say <color #000000><bgcolor #FFFFFF75><border #FF0000><scale 1.0><duration 10>Yay!")
+        target = SlashCommand(repr="say <color #000000><bgcolor #FFFFFF75><bordercolor #FF0000><scale 1.0><duration 10>Yay!")
         self.assertEqual(target.Name, name, "Did not parse name from formatting as expected")
         self.assertEqual(target.Text, text, "Did not parse text from formatting as expected")
         self.assertEqual(target.TextColor, color, "Did not parse color from formatting as expected")

--- a/SlashCommand.py
+++ b/SlashCommand.py
@@ -13,7 +13,7 @@ class SlashCommand():
     REPEAT_STR = "+"
     COLOR_STR = "color"
     BACKGROUND_STR = "bgcolor"
-    BORDER_STR = "border"
+    BORDER_STR = "bordercolor"
     SCALE_STR = "scale"
     DURATION_STR = "duration"
 
@@ -88,7 +88,7 @@ class SlashCommand():
         #background transparency indicated by transparency in <bgcolor {ccode{transparency}>
         self.TextBackgroundTransparency = ""
 
-        #border color indicated by <border {ccode} in text>
+        #border color indicated by <bordercolor {code} in text>
         self.TextBorderColor = ""
 
         #scale indicated by <scale {factor}> in text


### PR DESCRIPTION
Fixed bug where <border {color}> in text formatting should be <bordercolor {color}>